### PR TITLE
[Feature] Check file contents when updating a dataset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/ambv/black
+  - repo: https://github.com/psf/black
     rev: "19.3b0"
     hooks:
       - id: black

--- a/docs/TaigaClient API.md
+++ b/docs/TaigaClient API.md
@@ -1,12 +1,30 @@
 # Taigapy Documentation
 
 ## Table of Contents
-- [taigapy.TaigaClient](#taigapytaigaclient)
-- [taigapy.TaigaClient.get](#taigapytaigaclientget)
-- [taigapy.TaigaClient.download_to_cache](#taigapytaigaclientdownloadtocache)
-- [taigapy.TaigaClient.create_dataset](#taigapytaigaclientcreatedataset)
-- [taigapy.TaigaClient.update_dataset](#taigapytaigaclientupdatedataset)
-- [taigapy.TaigaClient.get_dataset_metadata](#taigapytaigaclientgetdatasetmetadata)
+- [Taigapy Documentation](#taigapy-documentation)
+  - [Table of Contents](#table-of-contents)
+  - [taigapy.TaigaClient](#taigapytaigaclient)
+    - [Parameters](#parameters)
+  - [taigapy.TaigaClient.get](#taigapytaigaclientget)
+    - [Parameters](#parameters-1)
+    - [Returns](#returns)
+    - [Examples](#examples)
+  - [taigapy.TaigaClient.download_to_cache](#taigapytaigaclientdownload_to_cache)
+    - [Parameters](#parameters-2)
+    - [Returns](#returns-1)
+    - [Examples](#examples-1)
+  - [taigapy.TaigaClient.create_dataset](#taigapytaigaclientcreate_dataset)
+    - [Parameters](#parameters-3)
+    - [Returns](#returns-2)
+    - [Examples](#examples-2)
+  - [taigapy.TaigaClient.update_dataset](#taigapytaigaclientupdate_dataset)
+    - [Parameters](#parameters-4)
+    - [Returns](#returns-3)
+    - [Examples](#examples-3)
+  - [taigapy.TaigaClient.get_dataset_metadata](#taigapytaigaclientget_dataset_metadata)
+    - [Parameters](#parameters-5)
+    - [Returns](#returns-4)
+    - [Examples](#examples-4)
 
 ## taigapy.TaigaClient
 ```python
@@ -194,7 +212,7 @@ dataset_version_id = taigapy.TaigaClient.update_dataset(
 ```
 Creates a new version of dataset specified by `dataset_id` or `dataset_name` (and optionally `dataset_version`).
 
-Follows the same rules as [taigapy.TaigaClient.create_dataset](#taigapytaigaclientcreatedataset)
+Follows the same rules as [taigapy.TaigaClient.create_dataset](#taigapytaigaclientcreatedataset). Additionally, if a local file listed in `upload_files` matches content (based on SHA256 and MD5 hashes) and [type](./Definitions.md#DataFile_Type)/[format](./Definitions.md#DataFile_Formats) of a datafile in the base dataset version, the local file will not be uploaded, and instead a virtual file will be created based on the existing datafile.
 
 ### Parameters
 See [taigapy.TaigaClient.get parameters](#Parameters-1) for description of `dataset_name`.\

--- a/docs/TaigaClient API.md
+++ b/docs/TaigaClient API.md
@@ -1,30 +1,12 @@
 # Taigapy Documentation
 
 ## Table of Contents
-- [Taigapy Documentation](#taigapy-documentation)
-  - [Table of Contents](#table-of-contents)
-  - [taigapy.TaigaClient](#taigapytaigaclient)
-    - [Parameters](#parameters)
-  - [taigapy.TaigaClient.get](#taigapytaigaclientget)
-    - [Parameters](#parameters-1)
-    - [Returns](#returns)
-    - [Examples](#examples)
-  - [taigapy.TaigaClient.download_to_cache](#taigapytaigaclientdownload_to_cache)
-    - [Parameters](#parameters-2)
-    - [Returns](#returns-1)
-    - [Examples](#examples-1)
-  - [taigapy.TaigaClient.create_dataset](#taigapytaigaclientcreate_dataset)
-    - [Parameters](#parameters-3)
-    - [Returns](#returns-2)
-    - [Examples](#examples-2)
-  - [taigapy.TaigaClient.update_dataset](#taigapytaigaclientupdate_dataset)
-    - [Parameters](#parameters-4)
-    - [Returns](#returns-3)
-    - [Examples](#examples-3)
-  - [taigapy.TaigaClient.get_dataset_metadata](#taigapytaigaclientget_dataset_metadata)
-    - [Parameters](#parameters-5)
-    - [Returns](#returns-4)
-    - [Examples](#examples-4)
+- [taigapy.TaigaClient](#taigapytaigaclient)
+- [taigapy.TaigaClient.get](#taigapytaigaclientget)
+- [taigapy.TaigaClient.download_to_cache](#taigapytaigaclientdownloadtocache)
+- [taigapy.TaigaClient.create_dataset](#taigapytaigaclientcreatedataset)
+- [taigapy.TaigaClient.update_dataset](#taigapytaigaclientupdatedataset)
+- [taigapy.TaigaClient.get_dataset_metadata](#taigapytaigaclientgetdatasetmetadata)
 
 ## taigapy.TaigaClient
 ```python

--- a/taigapy/__init__.py
+++ b/taigapy/__init__.py
@@ -6,7 +6,15 @@ import os
 import tempfile
 
 from collections import defaultdict
-from typing import Collection, DefaultDict, List, Optional, Tuple, Union
+from typing import (
+    Collection,
+    DefaultDict,
+    List,
+    MutableSequence,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import aiobotocore
 import colorful as cf
@@ -21,6 +29,8 @@ from taigapy.utils import (
     format_datafile_id_from_datafile_metadata,
     untangle_dataset_id_with_version,
     get_latest_valid_version_from_metadata,
+    modify_upload_files,
+    get_file_hashes,
 )
 from taigapy.types import (
     DataFileFormat,
@@ -28,6 +38,7 @@ from taigapy.types import (
     DatasetVersionState,
     DatasetMetadataDict,
     DatasetVersionMetadataDict,
+    DatasetVersionFiles,
     DataFileMetadata,
     S3Credentials,
     UploadDataFile,
@@ -345,51 +356,11 @@ class TaigaClient:
         print(cf.red("The datafile you requested was not in the cache."))
         return None
 
-    def _validate_upload_files(
-        self,
-        upload_files: Collection[UploadS3DataFileDict],
-        add_taiga_ids: Collection[UploadVirtualDataFileDict],
-        previous_version_taiga_ids: Optional[
-            Collection[UploadVirtualDataFileDict]
-        ] = None,
-    ) -> Tuple[List[UploadS3DataFile], List[UploadVirtualDataFile]]:
-        upload_s3_datafiles = [UploadS3DataFile(f) for f in upload_files]
-        upload_virtual_datafiles = [UploadVirtualDataFile(f) for f in add_taiga_ids]
-        previous_version_datafiles = (
-            [UploadVirtualDataFile(f) for f in previous_version_taiga_ids]
-            if previous_version_taiga_ids is not None
-            else None
-        )
-
-        # https://github.com/python/typeshed/issues/2383
-        all_upload_datafiles: Collection[
-            UploadDataFile
-        ] = upload_s3_datafiles + upload_virtual_datafiles  # type: ignore
-
-        datafile_names: DefaultDict[str, int] = defaultdict(int)
-        for upload_datafile in all_upload_datafiles:
-            datafile_names[upload_datafile.file_name] += 1
-
-        duplicate_file_names = [
-            file_name for file_name, count in datafile_names.items() if count > 1
-        ]
-        if len(duplicate_file_names) > 0:
-            raise ValueError(
-                "Multiple files named {}.".format(", ".join(duplicate_file_names))
-            )
-
-        if previous_version_taiga_ids is not None:
-            for upload_datafile in previous_version_datafiles:
-                if upload_datafile.file_name not in datafile_names:
-                    upload_virtual_datafiles.append(upload_datafile)
-
-        return upload_s3_datafiles, upload_virtual_datafiles
-
     def _validate_create_dataset_arguments(
         self,
         dataset_name: str,
-        upload_files: Optional[Collection[UploadS3DataFileDict]],
-        add_taiga_ids: Optional[Collection[UploadVirtualDataFileDict]],
+        upload_files: MutableSequence[UploadS3DataFileDict],
+        add_taiga_ids: MutableSequence[UploadVirtualDataFileDict],
         folder_id: Optional[str],
     ):
         if len(dataset_name) == 0:
@@ -397,7 +368,7 @@ class TaigaClient:
         if len(upload_files) == 0 and len(add_taiga_ids) == 0:
             raise ValueError("upload_files and add_taiga_ids cannot both be empty.")
 
-        upload_s3_datafiles, upload_virtual_datafiles = self._validate_upload_files(
+        upload_s3_datafiles, upload_virtual_datafiles = modify_upload_files(
             upload_files, add_taiga_ids
         )
 
@@ -414,8 +385,8 @@ class TaigaClient:
         dataset_permaname: Optional[str],
         dataset_version: Optional[DatasetVersion],
         changes_description: Optional[str],
-        upload_files: Optional[Collection[UploadS3DataFileDict]],
-        add_taiga_ids: Optional[Collection[UploadVirtualDataFileDict]],
+        upload_files: MutableSequence[UploadS3DataFileDict],
+        add_taiga_ids: MutableSequence[UploadVirtualDataFileDict],
         add_all_existing_files: bool,
     ) -> Tuple[
         List[UploadS3DataFile], List[UploadVirtualDataFile], DatasetVersionMetadataDict
@@ -456,20 +427,11 @@ class TaigaClient:
             dataset_permaname, dataset_version
         )
 
-        if add_all_existing_files:
-            existing_files: List[UploadVirtualDataFileDict] = [
-                {
-                    "taiga_id": format_datafile_id(
-                        dataset_permaname, dataset_version, datafile["name"]
-                    )
-                }
-                for datafile in dataset_version_metadata["datasetVersion"]["datafiles"]
-            ]
-        else:
-            existing_files = None
-
         upload_s3_datafiles, upload_virtual_datafiles = self._validate_upload_files(
-            upload_files, add_taiga_ids, existing_files
+            upload_files,
+            add_taiga_ids,
+            dataset_version_metadata,
+            add_all_existing_files,
         )
 
         return upload_s3_datafiles, upload_virtual_datafiles, dataset_version_metadata
@@ -610,8 +572,8 @@ class TaigaClient:
         self,
         dataset_name: str,
         dataset_description: Optional[str] = None,
-        upload_files: Optional[Collection[UploadS3DataFileDict]] = None,
-        add_taiga_ids: Optional[Collection[UploadVirtualDataFileDict]] = None,
+        upload_files: Optional[MutableSequence[UploadS3DataFileDict]] = None,
+        add_taiga_ids: Optional[MutableSequence[UploadVirtualDataFileDict]] = None,
         folder_id: str = None,
     ) -> Optional[str]:
         """Creates a new dataset named dataset_name with local files upload_files and virtual datafiles add_taiga_ids in the folder with id parent_folder_id.
@@ -693,8 +655,8 @@ class TaigaClient:
         dataset_version: Optional[DatasetVersion] = None,
         dataset_description: Optional[str] = None,
         changes_description: Optional[str] = None,
-        upload_files: Optional[Collection[UploadS3DataFileDict]] = None,
-        add_taiga_ids: Optional[Collection[UploadVirtualDataFileDict]] = None,
+        upload_files: Optional[MutableSequence[UploadS3DataFileDict]] = None,
+        add_taiga_ids: Optional[MutableSequence[UploadVirtualDataFileDict]] = None,
         add_all_existing_files: bool = False,
     ) -> str:
         """Creates a new version of dataset specified by dataset_id or dataset_name (and optionally dataset_version).
@@ -723,11 +685,6 @@ class TaigaClient:
         """
         self._set_token_and_initialized_api()
 
-        if upload_files is None:
-            upload_files = []
-        if add_taiga_ids is None:
-            add_taiga_ids = []
-
         try:
             (
                 upload_s3_datafiles,
@@ -738,8 +695,8 @@ class TaigaClient:
                 dataset_permaname,
                 dataset_version,
                 changes_description,
-                upload_files,
-                add_taiga_ids,
+                upload_files or [],
+                add_taiga_ids or [],
                 add_all_existing_files,
             )
         except ValueError as e:

--- a/taigapy/__init__.py
+++ b/taigapy/__init__.py
@@ -30,7 +30,6 @@ from taigapy.utils import (
     untangle_dataset_id_with_version,
     get_latest_valid_version_from_metadata,
     modify_upload_files,
-    get_file_hashes,
 )
 from taigapy.types import (
     DataFileFormat,
@@ -438,7 +437,7 @@ class TaigaClient:
             self.get_dataset_metadata(dataset_permaname, dataset_version)
         )
 
-        upload_s3_datafiles, upload_virtual_datafiles = self._validate_upload_files(
+        upload_s3_datafiles, upload_virtual_datafiles = modify_upload_files(
             upload_files,
             add_taiga_ids,
             dataset_version_metadata,

--- a/taigapy/taiga_cache.py
+++ b/taigapy/taiga_cache.py
@@ -44,7 +44,9 @@ def _write_csv_to_feather(
         # Feather does not support indexes
         df.reset_index().to_feather(feather_path)
     else:
-        df = pd.read_csv(csv_path, dtype=column_types, encoding=encoding, low_memory=False)
+        df = pd.read_csv(
+            csv_path, dtype=column_types, encoding=encoding, low_memory=False
+        )
         df.to_feather(feather_path)
 
     return df

--- a/taigapy/types.py
+++ b/taigapy/types.py
@@ -7,9 +7,6 @@ from typing import List, Optional, Union
 from typing_extensions import Literal, TypedDict
 
 
-from taigapy.utils import standardize_file_name
-
-
 class DataFileType(Enum):
     S3 = "s3"
     Virtual = "virtual"
@@ -203,6 +200,8 @@ class UploadDataFile(ABC):
 
 class UploadS3DataFile(UploadDataFile):
     def __init__(self, upload_s3_file_dict: UploadS3DataFileDict):
+        from taigapy.utils import standardize_file_name
+
         self.file_path = os.path.abspath(upload_s3_file_dict["path"])
         if not os.path.exists(self.file_path):
             raise Exception(

--- a/taigapy/types.py
+++ b/taigapy/types.py
@@ -7,6 +7,9 @@ from typing import List, Optional, Union
 from typing_extensions import Literal, TypedDict
 
 
+from taigapy.utils import standardize_file_name
+
+
 class DataFileType(Enum):
     S3 = "s3"
     Virtual = "virtual"
@@ -59,6 +62,8 @@ DatasetVersionFiles = TypedDict(
         "short_summary": str,
         "type": str,  # DataFileFormat
         "underlying_file_id": Optional[str],
+        "original_file_md5": Optional[str],
+        "original_file_sha256": Optional[str],
     },
 )
 DatasetVersionLongDict = TypedDict(
@@ -204,16 +209,12 @@ class UploadS3DataFile(UploadDataFile):
                 "File '{}' does not exist.".format(upload_s3_file_dict["path"])
             )
         self.file_name = upload_s3_file_dict.get(
-            "name", self._standardize_file_name(self.file_path)
+            "name", standardize_file_name(self.file_path)
         )
         self.datafile_format = DataFileUploadFormat(upload_s3_file_dict["format"])
         self.encoding = codecs.lookup(upload_s3_file_dict.get("encoding", "utf-8")).name
         self.bucket: Optional[str] = None
         self.key: Optional[str] = None
-
-    @staticmethod
-    def _standardize_file_name(file_name: str):
-        return os.path.basename(os.path.splitext(file_name)[0])
 
     def add_s3_upload_information(self, bucket: str, key: str):
         self.bucket = bucket

--- a/taigapy/utils.py
+++ b/taigapy/utils.py
@@ -1,6 +1,16 @@
+from collections import defaultdict
+import hashlib
 import os
 import re
-from typing import Iterable, Optional, Tuple
+from typing import (
+    Collection,
+    DefaultDict,
+    Iterable,
+    List,
+    MutableSequence,
+    Optional,
+    Tuple,
+)
 
 
 from taigapy.custom_exceptions import TaigaTokenFileNotFound
@@ -8,7 +18,12 @@ from taigapy.types import (
     DatasetVersion,
     DatasetMetadataDict,
     DatasetVersionMetadataDict,
+    DatasetVersionFiles,
     DataFileMetadata,
+    UploadDataFile,
+    UploadS3DataFileDict,
+    UploadVirtualDataFile,
+    UploadVirtualDataFileDict,
     S3Credentials,
     UploadS3DataFile,
 )
@@ -114,3 +129,114 @@ def get_latest_valid_version_from_metadata(
             latest_valid_version = version_num
 
     return str(latest_valid_version)
+
+
+def modify_upload_files(
+    upload_files: MutableSequence[UploadS3DataFileDict],
+    add_taiga_ids: MutableSequence[UploadVirtualDataFileDict],
+    dataset_version_metadata: Optional[DatasetVersionMetadataDict] = None,
+    add_all_existing_files: bool = False,
+) -> Tuple[List[UploadS3DataFile], List[UploadVirtualDataFile]]:
+    if dataset_version_metadata is not None:
+        dataset_permaname = dataset_version_metadata["dataset"]["permanames"][-1]
+        dataset_version = dataset_version_metadata["datasetVersion"]["version"]
+        datafiles = dataset_version_metadata["datasetVersion"]["datafiles"]
+
+        # For upload files that have the same content as file in the base dataset version,
+        # add the file as a virtual datafile instead of uploading it
+        add_as_virtual = {}
+        for upload_file_dict in upload_files:
+            sha256, md5 = get_file_hashes(upload_file_dict["path"])
+            matching_file: DatasetVersionFiles = next(
+                (
+                    f
+                    for f in datafiles
+                    if (
+                        f.get("original_file_sha256") == sha256
+                        and f.get("original_file_md5") == md5
+                    )
+                ),
+                None,
+            )
+
+            if matching_file is not None:
+                name = upload_file_dict.get(
+                    "name", standardize_file_name(upload_file_dict["path"])
+                )
+                taiga_id = (
+                    f"{dataset_permaname}.{dataset_version}/{matching_file['name']}"
+                )
+                add_as_virtual[upload_file_dict["name"]] = (name, taiga_id)
+
+        add_taiga_ids.extend(
+            {"taiga_id": taiga_id, "name": name}
+            for _, (name, taiga_id) in add_as_virtual.items()
+        )
+
+        upload_files = [
+            upload_file_dict
+            for upload_file_dict in upload_files
+            if upload_file_dict["path"] not in add_taiga_ids
+        ]
+
+    if add_all_existing_files:
+        previous_version_taiga_ids: List[UploadVirtualDataFileDict] = [
+            {
+                "taiga_id": format_datafile_id(
+                    dataset_permaname, dataset_version, datafile["name"]
+                )
+            }
+            for datafile in dataset_version_metadata["datasetVersion"]["datafiles"]
+        ]
+    else:
+        previous_version_taiga_ids = None
+
+    upload_s3_datafiles = [UploadS3DataFile(f) for f in upload_files]
+    upload_virtual_datafiles = [UploadVirtualDataFile(f) for f in add_taiga_ids]
+    previous_version_datafiles = (
+        [UploadVirtualDataFile(f) for f in previous_version_taiga_ids]
+        if previous_version_taiga_ids is not None
+        else None
+    )
+
+    # https://github.com/python/typeshed/issues/2383
+    all_upload_datafiles: Collection[
+        UploadDataFile
+    ] = upload_s3_datafiles + upload_virtual_datafiles  # type: ignore
+
+    datafile_names: DefaultDict[str, int] = defaultdict(int)
+    for upload_datafile in all_upload_datafiles:
+        datafile_names[upload_datafile.file_name] += 1
+
+    duplicate_file_names = [
+        file_name for file_name, count in datafile_names.items() if count > 1
+    ]
+    if len(duplicate_file_names) > 0:
+        raise ValueError(
+            "Multiple files named {}.".format(", ".join(duplicate_file_names))
+        )
+
+    if previous_version_taiga_ids is not None:
+        for upload_datafile in previous_version_datafiles:
+            if upload_datafile.file_name not in datafile_names:
+                upload_virtual_datafiles.append(upload_datafile)
+
+    return upload_s3_datafiles, upload_virtual_datafiles
+
+
+def standardize_file_name(file_name: str) -> str:
+    return os.path.basename(os.path.splitext(file_name)[0])
+
+
+def get_file_hashes(file_name: str) -> Tuple[str, str]:
+    """Returns the sha256 and md5 hashes for a file."""
+    sha256 = hashlib.sha256()
+    md5 = hashlib.md5()
+    with open(file_name, "rb") as fd:
+        while True:
+            buffer = fd.read(1024 * 1024)
+            if len(buffer) == 0:
+                break
+            sha256.update(buffer)
+            md5.update(buffer)
+    return sha256.hexdigest(), md5.hexdigest()

--- a/taigapy/utils.py
+++ b/taigapy/utils.py
@@ -49,9 +49,7 @@ def find_first_existing(paths: Iterable[str]):
     raise TaigaTokenFileNotFound(paths)
 
 
-def untangle_dataset_id_with_version(
-    taiga_id: str,
-) -> Tuple[str, str, Optional[str]]:
+def untangle_dataset_id_with_version(taiga_id: str,) -> Tuple[str, str, Optional[str]]:
     """Returns dataset_permaname, dataset_version, and datafile_name from
     `taiga_id` in the form dataset_permaname.version/datafile_name or
     dataset_permaname.version.
@@ -162,7 +160,9 @@ def modify_upload_files(
                         f.get("original_file_sha256") == sha256
                         and f.get("original_file_md5") == md5
                         and (
-                            DATAFILE_UPLOAD_FORMAT_TO_STORAGE_FORMAT[upload_file_dict["format"]]
+                            DATAFILE_UPLOAD_FORMAT_TO_STORAGE_FORMAT[
+                                upload_file_dict["format"]
+                            ]
                             == f.get("type")
                         )
                     )

--- a/tests/test_taiga_client.py
+++ b/tests/test_taiga_client.py
@@ -221,8 +221,8 @@ class TestGetMetadata:
             DATASET_PERMANAME
         )
 
-        dataset_version_metadata: DatasetVersionMetadataDict = taigaClient.get_dataset_metadata(
-            DATASET_PERMANAME, DATASET_VERSION
+        dataset_version_metadata: DatasetVersionMetadataDict = (
+            taigaClient.get_dataset_metadata(DATASET_PERMANAME, DATASET_VERSION)
         )
         keys = dataset_version_metadata.keys()
         assert all(k in keys for k in ["dataset", "datasetVersion"])
@@ -384,8 +384,8 @@ class TestUpdateDataset:
             changes_description="Nothing really",
         )
         assert dataset_version_id is not None
-        dataset_version_metadata: DatasetVersionMetadataDict = localTaigaClient.get_dataset_metadata(
-            dataset_metadata["permanames"][0], 2
+        dataset_version_metadata: DatasetVersionMetadataDict = (
+            localTaigaClient.get_dataset_metadata(dataset_metadata["permanames"][0], 2)
         )
         assert (
             dataset_version_metadata["datasetVersion"]["changes_description"]
@@ -411,8 +411,8 @@ class TestUpdateDataset:
             changes_description="Nothing really",
         )
         assert dataset_version_id is not None
-        dataset_version_metadata: DatasetVersionMetadataDict = localTaigaClient.get_dataset_metadata(
-            dataset_metadata["permanames"][0], 2
+        dataset_version_metadata: DatasetVersionMetadataDict = (
+            localTaigaClient.get_dataset_metadata(dataset_metadata["permanames"][0], 2)
         )
         assert (
             dataset_version_metadata["datasetVersion"]["changes_description"]
@@ -439,8 +439,8 @@ class TestUpdateDataset:
         )
 
         assert dataset_version_id is not None
-        dataset_version_metadata: DatasetVersionMetadataDict = localTaigaClient.get_dataset_metadata(
-            dataset_metadata["permanames"][0], 2
+        dataset_version_metadata: DatasetVersionMetadataDict = (
+            localTaigaClient.get_dataset_metadata(dataset_metadata["permanames"][0], 2)
         )
         assert len(dataset_version_metadata["datasetVersion"]["datafiles"]) == 2
 
@@ -465,8 +465,8 @@ class TestUpdateDataset:
         )
 
         assert dataset_version_id is not None
-        dataset_version_metadata: DatasetVersionMetadataDict = localTaigaClient.get_dataset_metadata(
-            dataset_metadata["permanames"][0], 2
+        dataset_version_metadata: DatasetVersionMetadataDict = (
+            localTaigaClient.get_dataset_metadata(dataset_metadata["permanames"][0], 2)
         )
         assert len(dataset_version_metadata["datasetVersion"]["datafiles"]) == 1
 

--- a/tests/test_taiga_utils.py
+++ b/tests/test_taiga_utils.py
@@ -1,6 +1,15 @@
+from typing import MutableSequence, Optional, List
+
 import pytest
 
-from taigapy.utils import untangle_dataset_id_with_version
+from taigapy.utils import untangle_dataset_id_with_version, modify_upload_files
+from taigapy.types import (
+    DatasetVersionMetadataDict,
+    UploadS3DataFile,
+    UploadS3DataFileDict,
+    UploadVirtualDataFile,
+    UploadVirtualDataFileDict,
+)
 
 
 @pytest.mark.parametrize(
@@ -20,3 +29,28 @@ def test_untangle_dataset_id_with_version(
     else:
         with pytest.raises(ValueError):
             untangle_dataset_id_with_version(test_input)
+
+
+@pytest.mark.parametrize(
+    "upload_files,add_taiga_ids,dataset_version_metadata,add_all_existing_files,expected_upload_s3_datafiles,expected_upload_virtual_datafiles",
+    [
+        pytest.param(
+            upload_files,
+            add_taiga_ids,
+            dataset_version_metadata,
+            add_all_existing_files,
+            expected_upload_s3_datafiles,
+            expected_upload_virtual_datafiles,
+            id="",
+        )
+    ],
+)
+def test_modify_upload_files(
+    upload_files: MutableSequence[UploadS3DataFileDict],
+    add_taiga_ids: MutableSequence[UploadVirtualDataFileDict],
+    dataset_version_metadata: Optional[DatasetVersionMetadataDict],
+    add_all_existing_files: bool,
+    expected_upload_s3_datafiles: List[UploadS3DataFile],
+    expected_upload_virtual_datafiles: List[UploadVirtualDataFile],
+):
+    pass

--- a/tests/test_taiga_utils.py
+++ b/tests/test_taiga_utils.py
@@ -1,5 +1,9 @@
-from typing import MutableSequence, Optional, List
+import copy
+import py
+from typing import Dict, MutableSequence, Optional, List
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from taigapy.utils import untangle_dataset_id_with_version, modify_upload_files
@@ -31,18 +35,232 @@ def test_untangle_dataset_id_with_version(
             untangle_dataset_id_with_version(test_input)
 
 
+upload_files: List[UploadS3DataFileDict] = [
+    {"path": "matrix.csv", "name": "Matrix", "format": "NumericMatrixCSV"},
+    {"path": "matrix_no_name.csv", "format": "NumericMatrixCSV"},
+    {"path": "table.csv", "name": "Table", "format": "TableCSV"},
+    {"path": "table_no_name.csv", "format": "TableCSV"},
+    {"path": "raw.txt", "name": "matching_datafile", "format": "Raw"},
+    {"path": "raw_no_name.txt", "format": "Raw"},
+]
+add_taiga_ids: List[UploadVirtualDataFileDict] = [
+    {"taiga_id": "foo.1/bar", "name": "Bar"},
+    {"taiga_id": "foo.1/no_name"},
+]
+dataset_version_metadata: DatasetVersionMetadataDict = {
+    "dataset": {
+        "can_edit": True,
+        "can_view": True,
+        "description": "dataset description",
+        "folders": [{"id": "folder-123", "name": "Folder"}],
+        "id": "dataset-id",
+        "name": "Dataset",
+        "permanames": ["dataset-0001"],
+        "versions": [
+            {
+                "id": "version-id-1",
+                "name": "1",
+                "state": "approved",
+            }
+        ],
+    },
+    "datasetVersion": {
+        "can_edit": True,
+        "can_view": True,
+        "changes_description": "changes",
+        "creation_date": "",
+        "creator": {},
+        "datafiles": [
+            {
+                "datafile_type": "s3",
+                "id": "datafile-1",
+                "name": "matching_datafile",
+                "short_summary": "",
+                "type": "Raw",
+                "original_file_md5": "a6087079aec78a575b7057d73bac3ec7",
+                "original_file_sha256": "91e3022709412414c5018b22ff545b0dda2a839c399fc3ffacb8e076568d4776",
+            },
+            {
+                "datafile_type": "s3",
+                "id": "datafile-2",
+                "name": "non_matching_datafile",
+                "short_summary": "",
+                "type": "Raw",
+                "original_file_md5": "",
+                "original_file_sha256": "",
+            },
+        ],
+        "dataset_id": "dataset-id",
+        "description": "dataset version description",
+        "id": "version-id-1",
+        "name": "1",
+        "reason_state": "",
+        "state": "approved",
+        "version": "1",
+    },
+}
+
+expected_upload_s3_datafiles_api_params: List[Dict] = [
+    {
+        "filename": "Matrix",
+        "filetype": "s3",
+        "s3Upload": {
+            "format": "NumericMatrixCSV",
+            "bucket": None,
+            "key": None,
+            "encoding": "utf-8",
+        },
+    },
+    {
+        "filename": "matrix_no_name",
+        "filetype": "s3",
+        "s3Upload": {
+            "format": "NumericMatrixCSV",
+            "bucket": None,
+            "key": None,
+            "encoding": "utf-8",
+        },
+    },
+    {
+        "filename": "Table",
+        "filetype": "s3",
+        "s3Upload": {
+            "format": "TableCSV",
+            "bucket": None,
+            "key": None,
+            "encoding": "utf-8",
+        },
+    },
+    {
+        "filename": "table_no_name",
+        "filetype": "s3",
+        "s3Upload": {
+            "format": "TableCSV",
+            "bucket": None,
+            "key": None,
+            "encoding": "utf-8",
+        },
+    },
+    {
+        "filename": "matching_datafile",
+        "filetype": "s3",
+        "s3Upload": {"format": "Raw", "bucket": None, "key": None, "encoding": "utf-8"},
+    },
+    {
+        "filename": "raw_no_name",
+        "filetype": "s3",
+        "s3Upload": {"format": "Raw", "bucket": None, "key": None, "encoding": "utf-8"},
+    },
+]
+expected_upload_virtual_datafiles_api_params: List[Dict] = [
+    {"filename": "Bar", "filetype": "virtual", "existingTaigaId": "foo.1/bar"},
+    {
+        "filename": "no_name",
+        "filetype": "virtual",
+        "existingTaigaId": "foo.1/no_name",
+    },
+]
+expected_add_existing_datafiles_api_params: List[Dict] = [
+    {
+        "filename": "matching_datafile",
+        "filetype": "virtual",
+        "existingTaigaId": "dataset-0001.1/matching_datafile",
+    },
+    {
+        "filename": "non_matching_datafile",
+        "filetype": "virtual",
+        "existingTaigaId": "dataset-0001.1/non_matching_datafile",
+    },
+]
+
+matrix_df = pd.DataFrame({"a": [2.1, np.nan], "b": [1.1, 1.4]}, index=["c", "d"])
+table_df = pd.DataFrame({"a": [2.1, np.nan], "b": ["one", "two"]})
+
+
 @pytest.mark.parametrize(
-    "upload_files,add_taiga_ids,dataset_version_metadata,add_all_existing_files,expected_upload_s3_datafiles,expected_upload_virtual_datafiles",
+    "upload_files,add_taiga_ids,dataset_version_metadata,add_all_existing_files,expected_upload_s3_datafiles_api_params,expected_upload_virtual_datafiles_api_params",
     [
         pytest.param(
-            upload_files,
-            add_taiga_ids,
+            copy.deepcopy(upload_files),
+            [],
+            None,
+            False,
+            expected_upload_s3_datafiles_api_params,
+            [],
+            id="create dataset, only upload files",
+        ),
+        pytest.param(
+            [],
+            copy.deepcopy(add_taiga_ids),
+            None,
+            False,
+            [],
+            expected_upload_virtual_datafiles_api_params,
+            id="create dataset, only virtual files",
+        ),
+        pytest.param(
+            copy.deepcopy(upload_files),
+            copy.deepcopy(add_taiga_ids),
+            None,
+            False,
+            expected_upload_s3_datafiles_api_params,
+            expected_upload_virtual_datafiles_api_params,
+            id="create dataset, both upload and virtual files",
+        ),
+        pytest.param(
+            copy.deepcopy(upload_files),
+            [],
             dataset_version_metadata,
-            add_all_existing_files,
-            expected_upload_s3_datafiles,
-            expected_upload_virtual_datafiles,
-            id="",
-        )
+            False,
+            [
+                f
+                for f in expected_upload_s3_datafiles_api_params
+                if f["filename"] != "matching_datafile"
+            ],
+            [
+                f
+                for f in expected_add_existing_datafiles_api_params
+                if f["filename"] == "matching_datafile"
+            ],
+            id="update dataset, only upload files, skip existsing files",
+        ),
+        pytest.param(
+            copy.deepcopy(upload_files),
+            [],
+            dataset_version_metadata,
+            True,
+            [
+                f
+                for f in expected_upload_s3_datafiles_api_params
+                if f["filename"] != "matching_datafile"
+            ],
+            expected_add_existing_datafiles_api_params,
+            id="update dataset, only upload files, add existing files",
+        ),
+        pytest.param(
+            [],
+            copy.deepcopy(add_taiga_ids),
+            dataset_version_metadata,
+            True,
+            [],
+            expected_upload_virtual_datafiles_api_params
+            + expected_add_existing_datafiles_api_params,
+            id="update dataset, only virtual files",
+        ),
+        pytest.param(
+            copy.deepcopy(upload_files),
+            copy.deepcopy(add_taiga_ids),
+            dataset_version_metadata,
+            True,
+            [
+                f
+                for f in expected_upload_s3_datafiles_api_params
+                if f["filename"] != "matching_datafile"
+            ],
+            expected_upload_virtual_datafiles_api_params
+            + expected_add_existing_datafiles_api_params,
+            id="update dataset, both upload and virtual files",
+        ),
     ],
 )
 def test_modify_upload_files(
@@ -50,7 +268,42 @@ def test_modify_upload_files(
     add_taiga_ids: MutableSequence[UploadVirtualDataFileDict],
     dataset_version_metadata: Optional[DatasetVersionMetadataDict],
     add_all_existing_files: bool,
-    expected_upload_s3_datafiles: List[UploadS3DataFile],
-    expected_upload_virtual_datafiles: List[UploadVirtualDataFile],
+    expected_upload_s3_datafiles_api_params: List[Dict],
+    expected_upload_virtual_datafiles_api_params: List[Dict],
+    tmpdir: py._path.local.LocalPath,
 ):
-    pass
+    for upload_file_dict in upload_files:
+        p = tmpdir.join(upload_file_dict["path"])
+        upload_file_dict["path"] = p
+        if upload_file_dict["format"] == "NumericMatrixCSV":
+            matrix_df.to_csv(p)
+        elif upload_file_dict["format"] == "TableCSV":
+            table_df.to_csv(p, index=False)
+        elif upload_file_dict.get("name") == "matching_datafile":
+            matrix_df.to_json(p)
+        else:
+            table_df.to_json(p)
+
+    upload_s3_datafiles, upload_virtual_datafiles = modify_upload_files(
+        upload_files,
+        add_taiga_ids,
+        dataset_version_metadata,
+        add_all_existing_files,
+    )
+    assert len(upload_s3_datafiles) == len(expected_upload_s3_datafiles_api_params)
+    assert all(
+        actual.to_api_param() == expected
+        for (actual, expected) in zip(
+            upload_s3_datafiles, expected_upload_s3_datafiles_api_params
+        )
+    )
+
+    assert len(upload_virtual_datafiles) == len(
+        expected_upload_virtual_datafiles_api_params
+    )
+    assert all(
+        actual.to_api_param() == expected
+        for (actual, expected) in zip(
+            upload_virtual_datafiles, expected_upload_virtual_datafiles_api_params
+        )
+    )


### PR DESCRIPTION
This PR adds a step to check the contents of files being uploaded to a dataset, and if the hashes (SHA256 and MD5) and file type (Raw, Columnar/TableCSV, HDF5/NumericMatrixCSV) match a file in the base dataset version, add the existing datafile as a virtual datafile instead of uploading the local file. 

Scripts that upload a batch of files may only be changing one at a time, especially in the case of fixing mistakes. It would be helpful if the TaigaClient didn't upload these duplications. The benefits would be:
- Faster upload
- Easier to tell which files actually changed in the Taiga UI when looking at the change log.
- Less wasted space