### PR TITLE
Feather support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "taigapy"
-version = "3.6.0"
+version = "3.7.0"
 description = "Client library for fetching data from Taiga"
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"

--- a/taigapy/__init__.py
+++ b/taigapy/__init__.py
@@ -4,6 +4,8 @@ __version__ = importlib.metadata.version("taigapy")
 
 from .consts import DEFAULT_TAIGA_URL, DEFAULT_CACHE_DIR, CACHE_FILE
 from .client import TaigaClient
+from .client_v3 import Client as ClientV3
+from .client_v3 import LocalFormat
 
 try:
     default_tc = TaigaClient()
@@ -13,7 +15,6 @@ except Exception as e:
         "You can import TaigaClient and add your custom options if you would want to customize it to your settings"
     )
 
-from .client_v3 import Client as ClientV3
 
 
 def create_taiga_client_v3(*args, **kwargs):

--- a/taigapy/taiga_api.py
+++ b/taigapy/taiga_api.py
@@ -45,7 +45,7 @@ def _standard_response_handler(
         raise TaigaServerError()
     elif r.status_code != 200:
         raise TaigaHttpException(
-            f"Bad status code ({r.status_code}) when POST {url} with params={params}"
+            f"Bad status code ({r.status_code}) when accessing {url} with params={params}"
         )
 
     return r.json()
@@ -115,15 +115,16 @@ class TaigaApi:
 
             params["taigapy_version"] = __version__
 
+            headers= dict(Authorization="Bearer " + self.token)
             r = requests.get(
                 url,
                 stream=True,
                 params=params,
-                headers=dict(Authorization="Bearer " + self.token),
+                headers=headers,
             )
 
             if standard_reponse_handling:
-                return _standard_response_handler(r, params)
+                return _standard_response_handler(r, params, url=url)
             else:
                 return r
 


### PR DESCRIPTION
Added support for downloading to cache in feather/arrow format. This is needed by taigr. 

Also updated `taigaclient` to use the v3 client, again, needed by taigr.