### PR TITLE
refactor: Generate and upload data previews using taigaclient while uploading a datafile

### DIFF
--- a/taigapy/client.py
+++ b/taigapy/client.py
@@ -590,7 +590,7 @@ class TaigaClient:
         add_taiga_ids: Optional[Sequence[UploadVirtualDataFileDict]] = None,
         add_gcs_files: Optional[Sequence[UploadGCSDataFileDict]] = None,
         folder_id: str = None,
-        upload_async: bool = True,
+        upload_async: bool = False,
     ) -> Optional[str]:
         """Creates a new dataset named dataset_name with local files upload_files and virtual datafiles add_taiga_ids in the folder with id parent_folder_id.
 

--- a/taigapy/client_v3.py
+++ b/taigapy/client_v3.py
@@ -117,6 +117,7 @@ class DatasetVersionFile:
     gs_path: Optional[str]
     datafile_id: str
     format: str
+    _server_id: Optional[str] = None
 
 
 @dataclass
@@ -185,12 +186,17 @@ def _create_s3_uploader(api: TaigaApi) -> Tuple[str, Uploader]:
     upload_session_id = api.create_upload_session()
     s3_credentials = api.get_s3_credentials()
 
-    s3_client = boto3.client(
-        "s3",
+    s3_kwargs = dict(
         aws_access_key_id=s3_credentials.access_key_id,
         aws_secret_access_key=s3_credentials.secret_access_key,
         aws_session_token=s3_credentials.session_token,
     )
+
+    if s3_credentials.endpoint_url:
+        s3_kwargs["endpoint_url"] = s3_credentials.endpoint_url
+        s3_kwargs["region_name"] = "us-east-1"
+
+    s3_client = boto3.client("s3", **s3_kwargs)
 
     def upload(local_path):
         bucket = s3_credentials.bucket
@@ -211,91 +217,90 @@ class MinDataFileMetadata:
     original_file_sha256: str
 
 
-def _count_csv_lines(path: str) -> int:
-    """Count data rows in a CSV file (excludes header)."""
-    count = 0
-    with open(path, "rb") as f:
-        for _ in f:
-            count += 1
-    return max(count - 1, 0)
+def _preview_hdf5(local_path: str) -> dict:
+    import h5py
+
+    with h5py.File(local_path, "r") as f:
+        num_rows = f["dim_0"].shape[0]
+        num_cols = f["dim_1"].shape[0]
+        row_names = [x.decode("utf8") for x in f["dim_0"][:PREVIEW_MAX_ROWS]]
+        col_names = [x.decode("utf8") for x in f["dim_1"][:PREVIEW_MAX_COLUMNS]]
+        data_slice = f["data"][:PREVIEW_MAX_ROWS, :PREVIEW_MAX_COLUMNS]
+
+    return {
+        "num_rows": num_rows,
+        "num_columns": num_cols,
+        "top_left_preview": {
+            "column_names": col_names,
+            "row_names": row_names,
+            "data": [[_json_safe(v) for v in row] for row in data_slice.tolist()],
+        },
+    }
+
+
+def _preview_parquet(local_path: str) -> dict:
+    from pyarrow import parquet as pq
+
+    pf = pq.ParquetFile(local_path)
+    num_rows = pf.metadata.num_rows
+    all_col_names = pf.schema_arrow.names
+    df = pd.read_parquet(local_path, columns=all_col_names[:PREVIEW_MAX_COLUMNS]).head(PREVIEW_MAX_ROWS)
+
+    has_named_index = not (isinstance(df.index, pd.RangeIndex) and df.index.name is None)
+    if has_named_index:
+        df = df.reset_index()
+
+    return {
+        "num_rows": num_rows,
+        "num_columns": len(all_col_names),
+        "top_left_preview": {
+            "column_names": list(df.columns[:PREVIEW_MAX_COLUMNS]),
+            "row_names": None,
+            "data": _dataframe_to_data(df, PREVIEW_MAX_COLUMNS),
+        },
+    }
+
+
+def _preview_csv_matrix(local_path: str) -> dict:
+    df = pd.read_csv(local_path, index_col=0)
+
+    return {
+        "num_rows": len(df),
+        "num_columns": len(df.columns),
+        "top_left_preview": {
+            "column_names": list(df.columns[:PREVIEW_MAX_COLUMNS]),
+            "row_names": [str(x) for x in df.index[:PREVIEW_MAX_ROWS]],
+            "data": _dataframe_to_data(df.head(PREVIEW_MAX_ROWS), PREVIEW_MAX_COLUMNS),
+        },
+    }
+
+
+def _preview_csv_table(local_path: str) -> dict:
+    df = pd.read_csv(local_path)
+
+    return {
+        "num_rows": len(df),
+        "num_columns": len(df.columns),
+        "top_left_preview": {
+            "column_names": list(df.columns[:PREVIEW_MAX_COLUMNS]),
+            "row_names": None,
+            "data": _dataframe_to_data(df.head(PREVIEW_MAX_ROWS), PREVIEW_MAX_COLUMNS),
+        },
+    }
 
 
 def _generate_preview_for_file(local_path: str, fmt: "LocalFormat") -> Optional[dict]:
-    """Generate a preview dict from a local file. Returns None if preview is not possible."""
-    import h5py
-    from pyarrow import parquet as pq
-
-    n = PREVIEW_MAX_ROWS
-    c = PREVIEW_MAX_COLUMNS
-
-    if fmt == LocalFormat.HDF5_MATRIX:
-        with h5py.File(local_path, "r") as f:
-            all_rows = [x.decode("utf8") for x in f["dim_0"]]
-            all_cols = [x.decode("utf8") for x in f["dim_1"]]
-            data_slice = f["data"][:n, :c]
-
-        return {
-            "num_rows": len(all_rows),
-            "num_columns": len(all_cols),
-            "top_left_preview": {
-                "column_names": all_cols[:c],
-                "row_names": all_rows[:n],
-                "data": [[_json_safe(v) for v in row] for row in data_slice.tolist()],
-            },
-        }
-
-    if fmt == LocalFormat.PARQUET_TABLE:
-        pf = pq.ParquetFile(local_path)
-        num_rows = pf.metadata.num_rows
-        all_col_names = pf.schema_arrow.names
-        cols_to_read = all_col_names[:c]
-        df = pd.read_parquet(local_path, columns=cols_to_read).head(n)
-
-        has_named_index = not (isinstance(df.index, pd.RangeIndex) and df.index.name is None)
-        if has_named_index:
-            df = df.reset_index()
-
-        return {
-            "num_rows": num_rows,
-            "num_columns": len(all_col_names),
-            "top_left_preview": {
-                "column_names": list(df.columns[:c]),
-                "row_names": None,
-                "data": _dataframe_to_data(df, c),
-            },
-        }
-
-    if fmt == LocalFormat.CSV_MATRIX:
-        df = pd.read_csv(local_path, index_col=0, nrows=n)
-        num_rows = _count_csv_lines(local_path)
-        all_col_names = list(pd.read_csv(local_path, index_col=0, nrows=0).columns)
-
-        return {
-            "num_rows": num_rows,
-            "num_columns": len(all_col_names),
-            "top_left_preview": {
-                "column_names": all_col_names[:c],
-                "row_names": [str(x) for x in df.index[:n]],
-                "data": _dataframe_to_data(df, c),
-            },
-        }
-
-    if fmt == LocalFormat.CSV_TABLE:
-        df = pd.read_csv(local_path, nrows=n)
-        num_rows = _count_csv_lines(local_path)
-        all_col_names = list(df.columns)
-
-        return {
-            "num_rows": num_rows,
-            "num_columns": len(all_col_names),
-            "top_left_preview": {
-                "column_names": all_col_names[:c],
-                "row_names": None,
-                "data": _dataframe_to_data(df, c),
-            },
-        }
-
-    return None
+    """Generate a preview dict from a local file. Returns None for unsupported formats."""
+    dispatch = {
+        LocalFormat.HDF5_MATRIX: _preview_hdf5,
+        LocalFormat.PARQUET_TABLE: _preview_parquet,
+        LocalFormat.CSV_MATRIX: _preview_csv_matrix,
+        LocalFormat.CSV_TABLE: _preview_csv_table,
+    }
+    handler = dispatch.get(fmt)
+    if handler is None:
+        return None
+    return handler(local_path)
 
 
 def _dataframe_to_data(df: pd.DataFrame, max_cols: int) -> List[List]:
@@ -309,9 +314,14 @@ def _dataframe_to_data(df: pd.DataFrame, max_cols: int) -> List[List]:
 
 def _json_safe(v):
     """Convert a value to something JSON-serializable. NaN/inf become None."""
-    if isinstance(v, float):
-        if pd.isna(v) or v == float("inf") or v == float("-inf"):
-            return None
+    import math
+
+    if v is None:
+        return None
+    if hasattr(v, "item"):
+        v = v.item()
+    if isinstance(v, float) and (math.isnan(v) or math.isinf(v)):
+        return None
     return v
 
 
@@ -772,7 +782,8 @@ class Client:
                 )
                 if preview_data is None:
                     continue
-                self.api.post_datafile_preview(dv_file.datafile_id, preview_data)
+                preview_id = dv_file._server_id or dv_file.datafile_id
+                self.api.post_datafile_preview(preview_id, preview_data)
                 log.info("Posted preview for %s", dv_file.name)
             except Exception:
                 log.warning(
@@ -894,6 +905,7 @@ class Client:
                         f"{permaname}.{version_number}/{f['name']}",
                     ),
                     format=f["type"],
+                    _server_id=f.get("id"),
                 )
                 for f in version_metadata["datasetVersion"]["datafiles"]
             ],

--- a/taigapy/client_v3.py
+++ b/taigapy/client_v3.py
@@ -192,6 +192,8 @@ def _create_s3_uploader(api: TaigaApi) -> Tuple[str, Uploader]:
         aws_session_token=s3_credentials.session_token,
     )
 
+    # This is necessary for local development using MiniStack where the 
+    # taigapy client can actually talk to the local taiga server.
     if s3_credentials.endpoint_url:
         s3_kwargs["endpoint_url"] = s3_credentials.endpoint_url
         s3_kwargs["region_name"] = "us-east-1"

--- a/taigapy/client_v3.py
+++ b/taigapy/client_v3.py
@@ -117,7 +117,7 @@ class DatasetVersionFile:
     gs_path: Optional[str]
     datafile_id: str
     format: str
-    _server_id: Optional[str] = None
+    server_id: Optional[str] = None
 
 
 @dataclass
@@ -261,30 +261,38 @@ def _preview_parquet(local_path: str) -> dict:
     }
 
 
+def _count_lines(path: str) -> int:
+    """Count lines in a file by streaming one line at a time"""
+    with open(path) as f:
+        return sum(1 for _ in f)
+
+
 def _preview_csv_matrix(local_path: str) -> dict:
-    df = pd.read_csv(local_path, index_col=0)
+    num_rows = _count_lines(local_path) - 1  # subtract header
+    df = pd.read_csv(local_path, index_col=0, nrows=PREVIEW_MAX_ROWS)
 
     return {
-        "num_rows": len(df),
+        "num_rows": num_rows,
         "num_columns": len(df.columns),
         "top_left_preview": {
             "column_names": list(df.columns[:PREVIEW_MAX_COLUMNS]),
             "row_names": [str(x) for x in df.index[:PREVIEW_MAX_ROWS]],
-            "data": _dataframe_to_data(df.head(PREVIEW_MAX_ROWS), PREVIEW_MAX_COLUMNS),
+            "data": _dataframe_to_data(df, PREVIEW_MAX_COLUMNS),
         },
     }
 
 
 def _preview_csv_table(local_path: str) -> dict:
-    df = pd.read_csv(local_path)
+    num_rows = _count_lines(local_path) - 1  # subtract header
+    df = pd.read_csv(local_path, nrows=PREVIEW_MAX_ROWS)
 
     return {
-        "num_rows": len(df),
+        "num_rows": num_rows,
         "num_columns": len(df.columns),
         "top_left_preview": {
             "column_names": list(df.columns[:PREVIEW_MAX_COLUMNS]),
             "row_names": None,
-            "data": _dataframe_to_data(df.head(PREVIEW_MAX_ROWS), PREVIEW_MAX_COLUMNS),
+            "data": _dataframe_to_data(df, PREVIEW_MAX_COLUMNS),
         },
     }
 
@@ -804,7 +812,7 @@ class Client:
                 )
                 if preview_data is None:
                     continue
-                preview_id = dv_file._server_id or dv_file.datafile_id
+                preview_id = dv_file.server_id or dv_file.datafile_id
                 self.api.post_datafile_preview(preview_id, preview_data)
                 log.info("Posted preview for %s", dv_file.name)
             except Exception:
@@ -927,7 +935,7 @@ class Client:
                         f"{permaname}.{version_number}/{f['name']}",
                     ),
                     format=f["type"],
-                    _server_id=f.get("id"),
+                    server_id=f.get("id"),
                 )
                 for f in version_metadata["datasetVersion"]["datafiles"]
             ],

--- a/taigapy/client_v3.py
+++ b/taigapy/client_v3.py
@@ -525,6 +525,28 @@ class Client:
                 f"Got an internal error when trying to get({repr(id)})"
             ) from ex
 
+    def get_preview(
+        self,
+        id: Optional[str] = None,
+        name: Optional[str] = None,
+        version: Optional[DatasetVersion] = None,
+        file: Optional[str] = None,
+    ) -> Optional[dict]:
+        """
+        Get the stored preview for a datafile. Returns None if no preview exists.
+        """
+        if id is None:
+            assert name is not None
+            assert file is not None
+
+            if version is None:
+                dataset_metadata = self.api.get_dataset_version_metadata(name, None)
+                version = get_latest_valid_version_from_metadata(dataset_metadata)
+
+            id = f"{name}.{version}/{file}"
+
+        return self.api.get_datafile_preview(id)
+
     def _get(self, datafile_id: str, only_use_cache=False) -> pd.DataFrame:
         """
         Retrieve the specified file as a pandas.Dataframe

--- a/taigapy/client_v3.py
+++ b/taigapy/client_v3.py
@@ -17,6 +17,7 @@ from .simple_cache import Cache
 from .types import DataFileUploadFormat
 from .format_utils import read_hdf5, read_parquet, convert_csv_to_parquet
 from taigapy.utils import get_latest_valid_version_from_metadata
+from taigapy.consts import PREVIEW_MAX_ROWS, PREVIEW_MAX_COLUMNS
 from typing import Union
 from google.cloud import storage, exceptions as gcs_exceptions
 from . import utils
@@ -208,6 +209,110 @@ class MinDataFileMetadata:
     type: str
     custom_metadata: Dict[str, str]
     original_file_sha256: str
+
+
+def _count_csv_lines(path: str) -> int:
+    """Count data rows in a CSV file (excludes header)."""
+    count = 0
+    with open(path, "rb") as f:
+        for _ in f:
+            count += 1
+    return max(count - 1, 0)
+
+
+def _generate_preview_for_file(local_path: str, fmt: "LocalFormat") -> Optional[dict]:
+    """Generate a preview dict from a local file. Returns None if preview is not possible."""
+    import h5py
+    from pyarrow import parquet as pq
+
+    n = PREVIEW_MAX_ROWS
+    c = PREVIEW_MAX_COLUMNS
+
+    if fmt == LocalFormat.HDF5_MATRIX:
+        with h5py.File(local_path, "r") as f:
+            all_rows = [x.decode("utf8") for x in f["dim_0"]]
+            all_cols = [x.decode("utf8") for x in f["dim_1"]]
+            data_slice = f["data"][:n, :c]
+
+        return {
+            "num_rows": len(all_rows),
+            "num_columns": len(all_cols),
+            "top_left_preview": {
+                "column_names": all_cols[:c],
+                "row_names": all_rows[:n],
+                "data": [[_json_safe(v) for v in row] for row in data_slice.tolist()],
+            },
+        }
+
+    if fmt == LocalFormat.PARQUET_TABLE:
+        pf = pq.ParquetFile(local_path)
+        num_rows = pf.metadata.num_rows
+        all_col_names = pf.schema_arrow.names
+        cols_to_read = all_col_names[:c]
+        df = pd.read_parquet(local_path, columns=cols_to_read).head(n)
+
+        has_named_index = not (isinstance(df.index, pd.RangeIndex) and df.index.name is None)
+        if has_named_index:
+            df = df.reset_index()
+
+        return {
+            "num_rows": num_rows,
+            "num_columns": len(all_col_names),
+            "top_left_preview": {
+                "column_names": list(df.columns[:c]),
+                "row_names": None,
+                "data": _dataframe_to_data(df, c),
+            },
+        }
+
+    if fmt == LocalFormat.CSV_MATRIX:
+        df = pd.read_csv(local_path, index_col=0, nrows=n)
+        num_rows = _count_csv_lines(local_path)
+        all_col_names = list(pd.read_csv(local_path, index_col=0, nrows=0).columns)
+
+        return {
+            "num_rows": num_rows,
+            "num_columns": len(all_col_names),
+            "top_left_preview": {
+                "column_names": all_col_names[:c],
+                "row_names": [str(x) for x in df.index[:n]],
+                "data": _dataframe_to_data(df, c),
+            },
+        }
+
+    if fmt == LocalFormat.CSV_TABLE:
+        df = pd.read_csv(local_path, nrows=n)
+        num_rows = _count_csv_lines(local_path)
+        all_col_names = list(df.columns)
+
+        return {
+            "num_rows": num_rows,
+            "num_columns": len(all_col_names),
+            "top_left_preview": {
+                "column_names": all_col_names[:c],
+                "row_names": None,
+                "data": _dataframe_to_data(df, c),
+            },
+        }
+
+    return None
+
+
+def _dataframe_to_data(df: pd.DataFrame, max_cols: int) -> List[List]:
+    """Convert a DataFrame to a list-of-lists, handling NaN -> None."""
+    subset = df.iloc[:, :max_cols]
+    return [
+        [_json_safe(v) for v in row]
+        for row in subset.values.tolist()
+    ]
+
+
+def _json_safe(v):
+    """Convert a value to something JSON-serializable. NaN/inf become None."""
+    if isinstance(v, float):
+        if pd.isna(v) or v == float("inf") or v == float("-inf"):
+            return None
+    return v
 
 
 class Client:
@@ -648,6 +753,33 @@ class Client:
 
         return upload_session_id
 
+    def _upload_previews(
+        self, files: List[File], dataset_version: "DatasetVersion"
+    ):
+        """Best-effort: generate and POST previews for each uploaded file."""
+        uploaded_by_name = {}
+        for f in files:
+            if isinstance(f, UploadedFile):
+                uploaded_by_name[f.name] = f
+
+        for dv_file in dataset_version.files:
+            uploaded = uploaded_by_name.get(dv_file.name)
+            if uploaded is None:
+                continue
+            try:
+                preview_data = _generate_preview_for_file(
+                    uploaded.local_path, uploaded.format
+                )
+                if preview_data is None:
+                    continue
+                self.api.post_datafile_preview(dv_file.datafile_id, preview_data)
+                log.info("Posted preview for %s", dv_file.name)
+            except Exception:
+                log.warning(
+                    "Failed to generate/post preview for %s", dv_file.name,
+                    exc_info=True,
+                )
+
     def _upload_file(self, upload_session_id, uploader: Uploader, upload: File):
         # one method for each type of file we can upload
         def _upload_uploaded_file(upload_file: UploadedFile):
@@ -813,7 +945,9 @@ class Client:
 
         dataset_version_id = metadata["versions"][0]["id"]
 
-        return self._dataset_version_summary(dataset_version_id)
+        result = self._dataset_version_summary(dataset_version_id)
+        self._upload_previews(files, result)
+        return result
 
     def replace_dataset(
         self,
@@ -848,7 +982,9 @@ class Client:
             add_existing_files=False,
         )
 
-        return self._dataset_version_summary(dataset_version_id)
+        result = self._dataset_version_summary(dataset_version_id)
+        self._upload_previews(files, result)
+        return result
 
     def update_dataset(
         self,
@@ -900,7 +1036,9 @@ class Client:
                 add_existing_files=True,
             )
 
-        return self._dataset_version_summary(dataset_version_id)
+        result = self._dataset_version_summary(dataset_version_id)
+        self._upload_previews(additions, result)
+        return result
 
     def _download_to_cache(self, datafile_id: str, *, format: str = "raw_test") -> str:
         try:

--- a/taigapy/consts.py
+++ b/taigapy/consts.py
@@ -4,3 +4,6 @@ DEFAULT_TAIGA_URL = "https://cds.team/taiga"
 # which is often useful in adhoc scripts being submitted onto the cluster.
 DEFAULT_CACHE_DIR = "~/.taiga"
 CACHE_FILE = ".cache.db"
+
+PREVIEW_MAX_ROWS = 50
+PREVIEW_MAX_COLUMNS = 50

--- a/taigapy/taiga_api.py
+++ b/taigapy/taiga_api.py
@@ -454,6 +454,18 @@ class TaigaApi:
 
         return new_dataset_version_id
 
+    def post_datafile_preview(self, datafile_id: str, preview_data: dict):
+        api_endpoint = "/api/datafile-preview/{}".format(datafile_id)
+        r = self._request_post(
+            api_endpoint, data=preview_data, standard_reponse_handling=False
+        )
+        if r.status_code not in (200, 201):
+            raise TaigaHttpException(
+                "Failed to post preview for {}: status {}".format(
+                    datafile_id, r.status_code
+                )
+            )
+
     def upload_to_gcs(self, datafile_id: str, dest_gcs_path: str):
         api_endpoint = "/api/datafile/copy_to_google_bucket"
         params = {"datafile_id": datafile_id, "gcs_path": dest_gcs_path}

--- a/taigapy/taiga_api.py
+++ b/taigapy/taiga_api.py
@@ -466,6 +466,19 @@ class TaigaApi:
                 )
             )
 
+    def get_datafile_preview(self, datafile_id: str) -> Optional[dict]:
+        api_endpoint = "/api/datafile-preview/{}".format(datafile_id)
+        r = self._request_get(api_endpoint, standard_reponse_handling=False)
+        if r.status_code == 404:
+            return None
+        if r.status_code != 200:
+            raise TaigaHttpException(
+                "Failed to get preview for {}: status {}".format(
+                    datafile_id, r.status_code
+                )
+            )
+        return r.json()
+
     def upload_to_gcs(self, datafile_id: str, dest_gcs_path: str):
         api_endpoint = "/api/datafile/copy_to_google_bucket"
         params = {"datafile_id": datafile_id, "gcs_path": dest_gcs_path}

--- a/taigapy/types.py
+++ b/taigapy/types.py
@@ -195,7 +195,7 @@ class S3Credentials:
         self.prefix: str = s3_credentials_dict["prefix"]
         self.secret_access_key: str = s3_credentials_dict["secretAccessKey"]
         self.session_token: str = s3_credentials_dict["sessionToken"]
-
+        self.endpoint_url: Optional[str] = s3_credentials_dict.get("endpointUrl")
 
 UploadS3DataFileDict = TypedDict(
     "UploadS3DataFileDict",

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,0 +1,252 @@
+import numpy as np
+import pandas as pd
+
+from taigapy.client_v3 import (
+    Client,
+    LocalFormat,
+    UploadedFile,
+    _generate_preview_for_file,
+    _json_safe,
+)
+from taigapy.consts import PREVIEW_MAX_ROWS, PREVIEW_MAX_COLUMNS
+from taigapy.format_utils import write_hdf5, write_parquet
+
+
+# ---------------------------------------------------------------------------
+# Test _json_safe
+# ---------------------------------------------------------------------------
+
+class TestJsonSafe:
+    def test_nan(self):
+        assert _json_safe(float("nan")) is None
+
+    def test_inf(self):
+        assert _json_safe(float("inf")) is None
+        assert _json_safe(float("-inf")) is None
+
+    def test_none(self):
+        assert _json_safe(None) is None
+
+    def test_numpy_int(self):
+        result = _json_safe(np.int64(42))
+        assert result == 42
+        assert type(result) is int
+
+    def test_numpy_float(self):
+        result = _json_safe(np.float32(3.14))
+        assert isinstance(result, float)
+        assert abs(result - 3.14) < 0.001
+
+    def test_numpy_nan(self):
+        assert _json_safe(np.float64("nan")) is None
+
+    def test_numpy_bool(self):
+        result = _json_safe(np.bool_(True))
+        assert result is True
+        assert type(result) is bool
+
+    def test_regular_values_pass_through(self):
+        assert _json_safe("hello") == "hello"
+        assert _json_safe(42) == 42
+        assert _json_safe(3.14) == 3.14
+
+
+# ---------------------------------------------------------------------------
+# Test _generate_preview_for_file — one test per format
+# ---------------------------------------------------------------------------
+
+class TestGeneratePreviewCSVTable:
+    def test_basic(self, tmp_path):
+        df = pd.DataFrame({"col_a": [1, 2, 3], "col_b": ["x", "y", "z"]})
+        path = str(tmp_path / "table.csv")
+        df.to_csv(path, index=False)
+
+        preview = _generate_preview_for_file(path, LocalFormat.CSV_TABLE)
+
+        assert preview["num_rows"] == 3
+        assert preview["num_columns"] == 2
+        tlp = preview["top_left_preview"]
+        assert tlp["column_names"] == ["col_a", "col_b"]
+        assert tlp["row_names"] is None
+        assert len(tlp["data"]) == 3
+        assert tlp["data"][0] == [1, "x"]
+
+
+class TestGeneratePreviewCSVMatrix:
+    def test_basic(self, tmp_path):
+        df = pd.DataFrame(
+            {"gene_a": [0.1, 0.2], "gene_b": [0.3, 0.4]},
+            index=["cell_1", "cell_2"],
+        )
+        path = str(tmp_path / "matrix.csv")
+        df.to_csv(path)
+
+        preview = _generate_preview_for_file(path, LocalFormat.CSV_MATRIX)
+
+        assert preview["num_rows"] == 2
+        assert preview["num_columns"] == 2
+        tlp = preview["top_left_preview"]
+        assert tlp["column_names"] == ["gene_a", "gene_b"]
+        assert tlp["row_names"] == ["cell_1", "cell_2"]
+        assert tlp["data"][0] == [0.1, 0.3]
+
+
+class TestGeneratePreviewHDF5:
+    def test_basic(self, tmp_path):
+        df = pd.DataFrame(
+            {"g1": [1.0, 2.0, 3.0], "g2": [4.0, 5.0, 6.0]},
+            index=["r1", "r2", "r3"],
+        )
+        path = str(tmp_path / "matrix.hdf5")
+        write_hdf5(df, path)
+
+        preview = _generate_preview_for_file(path, LocalFormat.HDF5_MATRIX)
+
+        assert preview["num_rows"] == 3
+        assert preview["num_columns"] == 2
+        tlp = preview["top_left_preview"]
+        assert tlp["column_names"] == ["g1", "g2"]
+        assert tlp["row_names"] == ["r1", "r2", "r3"]
+        assert tlp["data"][0] == [1.0, 4.0]
+
+
+class TestGeneratePreviewParquet:
+    def test_basic(self, tmp_path):
+        df = pd.DataFrame({"x": [10, 20], "y": [30, 40]})
+        path = str(tmp_path / "table.parquet")
+        write_parquet(df, path)
+
+        preview = _generate_preview_for_file(path, LocalFormat.PARQUET_TABLE)
+
+        assert preview["num_rows"] == 2
+        assert preview["num_columns"] == 2
+        tlp = preview["top_left_preview"]
+        assert tlp["column_names"] == ["x", "y"]
+        assert tlp["row_names"] is None
+        assert tlp["data"] == [[10, 30], [20, 40]]
+
+
+class TestGeneratePreviewRaw:
+    def test_returns_none(self, tmp_path):
+        path = str(tmp_path / "blob.bin")
+        with open(path, "wb") as f:
+            f.write(b"\x00\x01\x02")
+        assert _generate_preview_for_file(path, LocalFormat.RAW) is None
+
+
+# ---------------------------------------------------------------------------
+# Truncation: preview respects PREVIEW_MAX_ROWS / PREVIEW_MAX_COLUMNS
+# ---------------------------------------------------------------------------
+
+class TestPreviewTruncation:
+    def test_csv_table_truncates(self, tmp_path):
+        n_rows = PREVIEW_MAX_ROWS + 20
+        n_cols = PREVIEW_MAX_COLUMNS + 10
+        df = pd.DataFrame(
+            np.random.rand(n_rows, n_cols),
+            columns=[f"c{i}" for i in range(n_cols)],
+        )
+        path = str(tmp_path / "big.csv")
+        df.to_csv(path, index=False)
+
+        preview = _generate_preview_for_file(path, LocalFormat.CSV_TABLE)
+
+        assert preview["num_rows"] == n_rows
+        assert preview["num_columns"] == n_cols
+        tlp = preview["top_left_preview"]
+        assert len(tlp["column_names"]) == PREVIEW_MAX_COLUMNS
+        assert len(tlp["data"]) == PREVIEW_MAX_ROWS
+        assert len(tlp["data"][0]) == PREVIEW_MAX_COLUMNS
+
+    def test_hdf5_truncates(self, tmp_path):
+        n_rows = PREVIEW_MAX_ROWS + 10
+        n_cols = PREVIEW_MAX_COLUMNS + 5
+        df = pd.DataFrame(
+            np.random.rand(n_rows, n_cols),
+            columns=[f"c{i}" for i in range(n_cols)],
+            index=[f"r{i}" for i in range(n_rows)],
+        )
+        path = str(tmp_path / "big.hdf5")
+        write_hdf5(df, path)
+
+        preview = _generate_preview_for_file(path, LocalFormat.HDF5_MATRIX)
+
+        assert preview["num_rows"] == n_rows
+        assert preview["num_columns"] == n_cols
+        tlp = preview["top_left_preview"]
+        assert len(tlp["column_names"]) == PREVIEW_MAX_COLUMNS
+        assert len(tlp["row_names"]) == PREVIEW_MAX_ROWS
+        assert len(tlp["data"]) == PREVIEW_MAX_ROWS
+        assert len(tlp["data"][0]) == PREVIEW_MAX_COLUMNS
+
+
+# ---------------------------------------------------------------------------
+# NaN handling in generated previews
+# ---------------------------------------------------------------------------
+
+class TestPreviewNaNHandling:
+    def test_csv_with_nan(self, tmp_path):
+        df = pd.DataFrame({"a": [1.0, float("nan"), 3.0], "b": [float("nan"), 5.0, 6.0]})
+        path = str(tmp_path / "nan.csv")
+        df.to_csv(path, index=False)
+
+        preview = _generate_preview_for_file(path, LocalFormat.CSV_TABLE)
+        data = preview["top_left_preview"]["data"]
+
+        assert data[0] == [1.0, None]
+        assert data[1] == [None, 5.0]
+
+
+# ---------------------------------------------------------------------------
+# Test Integration: create_dataset triggers preview upload
+# ---------------------------------------------------------------------------
+
+class TestUploadPreviewIntegration:
+    def test_create_dataset_posts_preview(self, mock_client: Client, tmpdir, s3_mock_client):
+        sample_file = tmpdir.join("table.csv")
+        df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+        df.to_csv(str(sample_file), index=False)
+
+        mock_client.create_dataset(
+            "test",
+            "desc",
+            [
+                UploadedFile(
+                    name="my_table",
+                    local_path=str(sample_file),
+                    format=LocalFormat.CSV_TABLE,
+                    custom_metadata={},
+                )
+            ],
+        )
+
+        mock_client.api.post_datafile_preview.assert_called_once()
+        call_args = mock_client.api.post_datafile_preview.call_args
+        preview_data = call_args[0][1]
+        assert preview_data["num_rows"] == 2
+        assert preview_data["num_columns"] == 2
+        assert preview_data["top_left_preview"]["column_names"] == ["x", "y"]
+
+    def test_preview_failure_does_not_block_upload(self, mock_client: Client, tmpdir, s3_mock_client):
+        """If preview POST fails, create_dataset still returns successfully."""
+        mock_client.api.post_datafile_preview.side_effect = Exception("server error")
+
+        sample_file = tmpdir.join("table.csv")
+        df = pd.DataFrame({"x": [1, 2]})
+        df.to_csv(str(sample_file), index=False)
+
+        version = mock_client.create_dataset(
+            "test",
+            "desc",
+            [
+                UploadedFile(
+                    name="my_table",
+                    local_path=str(sample_file),
+                    format=LocalFormat.CSV_TABLE,
+                    custom_metadata={},
+                )
+            ],
+        )
+
+        assert len(version.files) == 1
+        mock_client.api.post_datafile_preview.assert_called_once()

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,5 +1,8 @@
 import numpy as np
 import pandas as pd
+import pytest
+
+from conftest import add_mock_dataset_version
 
 from taigapy.client_v3 import (
     Client,
@@ -250,3 +253,30 @@ class TestUploadPreviewIntegration:
 
         assert len(version.files) == 1
         mock_client.api.post_datafile_preview.assert_called_once()
+
+
+class TestGetPreview:
+    def test_with_id(self, mock_client: Client):
+        expected = {"num_rows": 10, "num_columns": 3, "top_left_preview": {"column_names": ["a"], "row_names": ["r1"], "data": [[1]]}}
+        mock_client.api.get_datafile_preview.return_value = expected
+
+        result = mock_client.get_preview(id="my-dataset.1/my_table")
+
+        mock_client.api.get_datafile_preview.assert_called_once_with("my-dataset.1/my_table")
+        assert result == expected
+
+    def test_with_name_version_file(self, mock_client: Client, mock_db):
+        add_mock_dataset_version(mock_db, "my-dataset", 2, [{"name": "tbl", "format": "HDF5"}])
+        expected = {"num_rows": 5}
+        mock_client.api.get_datafile_preview.return_value = expected
+
+        result = mock_client.get_preview(name="my-dataset", version=2, file="tbl")
+
+        mock_client.api.get_datafile_preview.assert_called_once_with("my-dataset.2/tbl")
+        assert result == expected
+
+    def test_returns_none_when_no_preview(self, mock_client: Client):
+        mock_client.api.get_datafile_preview.return_value = None
+
+        result = mock_client.get_preview(id="my-dataset.1/my_table")
+        assert result is None


### PR DESCRIPTION
This PR has a companion PR in taiga: https://github.com/broadinstitute/taiga/pull/23

It does the following: 
- On `create_dataset`, `replace_dataset`, and `update_dataset`, the client now generates a preview (top-left 50x50 corner, total dimensions) from each uploaded file and POSTs it to the server's new `/api/datafile-preview/{id}` endpoint
- Add `Client.get_preview()` method with the same `id`/`name`/`version`/`file` interface as `get()`, returning the stored preview dict or `None`
- Preview upload is best-effort: failures are logged but never block the dataset upload
- Add S3 `endpoint_url` passthrough for local development with MiniStack